### PR TITLE
Fix mwe2 workflow launch in the Oomph setup file

### DIFF
--- a/org.xpect.releng/Xpect.setup
+++ b/org.xpect.releng/Xpect.setup
@@ -173,6 +173,12 @@
         launcher="/org.xpect.releng/GenerateXpect.launch">
       <description>Generate Xpect Language</description>
     </setupTask>
+    <setupTask
+        xsi:type="launching:LaunchTask"
+        id="GenerateXpectLanguage2"
+        launcher="/org.xpect.releng/GenerateXpect.launch">
+      <description>Generate Xpect Language</description>
+    </setupTask>
     <stream
         name="master"/>
     <description>Xpect Source Code</description>


### PR DESCRIPTION
It is a kind of hack, but adding another LaunchTask makes the mwe2 workflow run successfully, I think because the first one refreshes the workspace and thus the second run works.