### PR TITLE
Fixed #188: Mixed XPECT errors and XPECT warnings confuse the diff

### DIFF
--- a/org.xpect.tests/src/org/xpect/tests/text/StringSimilarityFunctionTest.xtend
+++ b/org.xpect.tests/src/org/xpect/tests/text/StringSimilarityFunctionTest.xtend
@@ -4,6 +4,7 @@ import org.junit.Test
 import static org.junit.Assert.*
 import org.xpect.util.IDifferencer.ISimilarityFunction
 import org.xpect.text.StringEndsSimilarityFunction
+import java.util.Locale
 
 class StringSimilarityFunctionTest {
 	@Test def void testEqual() {
@@ -109,10 +110,18 @@ class StringSimilarityFunctionTest {
 	}
 
 	def String similarityStr(Pair<String, String> ... pairs) {
-		pairs.map['''«key» <> «value» --> «String.format("%.2f", similarity(key, value))»'''].join("\n")
+		pairs.map['''«key» <> «value» --> «format(similarity(key, value))»'''].join("\n")
 	}
 
 	def float similarity(String s1, String s2) {
 		new StringEndsSimilarityFunction().similarity(s1, s2)
+	}
+	
+	/**
+	 * Defines a reproducible float output format for the test, using US locale.
+	 */
+	def String format(float value)
+	{
+		String.format(Locale.US,"%.2f", value)
 	}
 }

--- a/org.xpect.xtext.lib.tests/src/org/xpect/xtext/lib/tests/validation/IssuesTest.java
+++ b/org.xpect.xtext.lib.tests/src/org/xpect/xtext/lib/tests/validation/IssuesTest.java
@@ -1,0 +1,16 @@
+package org.xpect.xtext.lib.tests.validation;
+
+import org.junit.runner.RunWith;
+import org.xpect.XpectImport;
+import org.xpect.runner.XpectRunner;
+import org.xpect.runner.XpectSuiteClasses;
+import org.xpect.xtext.lib.setup.XtextStandaloneSetup;
+import org.xpect.xtext.lib.tests.ValidationTest;
+import org.xpect.xtext.lib.tests.ValidationTestModuleSetup;
+
+@RunWith(XpectRunner.class)
+@XpectSuiteClasses({IssuesTest.class, ValidationTest.class})
+@XpectImport({XtextStandaloneSetup.class, ValidationTestModuleSetup.class})
+public class IssuesTest {
+
+}

--- a/org.xpect.xtext.lib.tests/src/org/xpect/xtext/lib/tests/validation/errorsAndWarnings.xtext.xt
+++ b/org.xpect.xtext.lib.tests/src/org/xpect/xtext/lib/tests/validation/errorsAndWarnings.xtext.xt
@@ -1,0 +1,13 @@
+/*  XPECT_SETUP org.xpect.xtext.lib.tests.validation.IssuesTest END_SETUP */
+
+grammar org.xpect.tests.parameter.Offset hidden()
+
+import "http://www.eclipse.org/emf/2002/Ecore" as ecore
+
+generate test "test"
+
+// XPECT errors --> "Test2 cannot be resolved to a rule" at "Test2"
+// XPECT warnings --> "The entry rule 'Root' may consume non empty input without object instantiation. Add an action to ensure object creation, e.g. '{Root}'." at "Root" 
+Root: Test1 | Test2;
+
+Test1: "t";

--- a/org.xpect.xtext.lib.tests/src/org/xpect/xtext/lib/tests/validation/issues.xtext.xt
+++ b/org.xpect.xtext.lib.tests/src/org/xpect/xtext/lib/tests/validation/issues.xtext.xt
@@ -1,0 +1,15 @@
+/*  XPECT_SETUP org.xpect.xtext.lib.tests.validation.IssuesTest END_SETUP */
+
+grammar org.xpect.tests.parameter.Offset hidden()
+
+import "http://www.eclipse.org/emf/2002/Ecore" as ecore
+
+generate test "test"
+
+/* XPECT issues ---
+   "Test2 cannot be resolved to a rule" at "Test2"
+   "The entry rule 'Root' may consume non empty input without object instantiation. Add an action to ensure object creation, e.g. '{Root}'." at "Root" 
+--- */ 
+Root: Test1 | Test2;
+
+Test1: "t";

--- a/org.xpect.xtext.lib/src/org/xpect/xtext/lib/setup/XtextValidatingSetup.java
+++ b/org.xpect.xtext.lib/src/org/xpect/xtext/lib/setup/XtextValidatingSetup.java
@@ -72,7 +72,7 @@ public class XtextValidatingSetup extends ValidatingSetup {
 		IDiagnosticConverter converer = resource.getResourceServiceProvider().get(IDiagnosticConverter.class);
 		for (Diagnostic diagnostic : resource.getErrors())
 			converer.convertResourceDiagnostic(diagnostic, Severity.ERROR, new ListAcceptor<Issue>(result));
-		for (Diagnostic diagnostic : resource.getErrors())
+		for (Diagnostic diagnostic : resource.getWarnings())
 			converer.convertResourceDiagnostic(diagnostic, Severity.WARNING, new ListAcceptor<Issue>(result));
 		return result;
 	}

--- a/org.xpect.xtext.lib/src/org/xpect/xtext/lib/tests/ValidationTest.java
+++ b/org.xpect.xtext.lib/src/org/xpect/xtext/lib/tests/ValidationTest.java
@@ -35,6 +35,7 @@ import org.xpect.xtext.lib.util.NextLine;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
@@ -67,12 +68,19 @@ public class ValidationTest {
 	}
 
 	private Predicate<Issue> severityFilter(final Severity severity) {
-		return new Predicate<Issue>() {
-			@Override
-			public boolean apply(Issue input) {
-				return input.getSeverity() == severity;
-			}
-		};
+		if (severity == null) 
+		{
+			return Predicates.alwaysTrue();
+		}
+		else 
+		{
+			return new Predicate<Issue>() {
+				@Override
+				public boolean apply(Issue input) {
+					return input.getSeverity() == severity;
+				}
+			};
+		}
 	}
 
 	@Xpect

--- a/org.xpect.xtext.lib/src/org/xpect/xtext/lib/tests/ValidationTest.java
+++ b/org.xpect.xtext.lib/src/org/xpect/xtext/lib/tests/ValidationTest.java
@@ -34,6 +34,7 @@ import org.xpect.xtext.lib.util.IssueFormatter;
 import org.xpect.xtext.lib.util.NextLine;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
@@ -57,11 +58,21 @@ public class ValidationTest {
 
 	protected List<String> getActualIssues(Multimap<IRegion, Issue> line2issue, IRegion line, ValidationTestConfig cfg, Severity severity) {
 		Collection<Issue> issuesInLine = line2issue.get(line);
-		List<Issue> filteredIssues = Lists.newArrayList(filter(issuesInLine, cfg.getIgnoreFilter()));
+		List<Issue> filteredBySeverity = Lists.newArrayList(filter(issuesInLine,  severityFilter(severity)));
+		List<Issue> filteredIssues = Lists.newArrayList(filter(filteredBySeverity, cfg.getIgnoreFilter()));
 		List<String> formattedIssues = newArrayList(transform(filteredIssues, createIssueFormatter(line.getDocument(), severity)));
 		if (formattedIssues.isEmpty())
 			Assert.fail("No issues found in line " + line);
 		return formattedIssues;
+	}
+
+	private Predicate<Issue> severityFilter(final Severity severity) {
+		return new Predicate<Issue>() {
+			@Override
+			public boolean apply(Issue input) {
+				return input.getSeverity() == severity;
+			}
+		};
 	}
 
 	@Xpect

--- a/org.xpect/src/org/xpect/XpectImport.java
+++ b/org.xpect/src/org/xpect/XpectImport.java
@@ -6,6 +6,31 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.xpect.runner.Xpect;
+import org.xpect.setup.XpectGuiceModule;
+import org.xpect.setup.XpectSetupComponent;
+import org.xpect.setup.XpectSetupFactory;
+import org.xpect.setup.XpectSetupRoot;
+
+/**
+ * This Annotation is used on a class with @Xpect methods to define what contributions should be present in the Xpect Test Setup. Possible contributions are classes annotated with
+ * these Xpect roles:
+ * <ul>
+ * <li>@{@link XpectSetupFactory}: Provides objects that can be injected into @Xpect methods and other contributions.</li>
+ * <li>@{@link XpectSetupComponent}: The class is available in the XPECT_SETUP section, if it is a parameter of some @XpectSetupRoot-annotated class' add(foo) method. These
+ * classes will also be proposed by content assist.</li>
+ * <li>@{@link XpectSetupRoot}: The types of the add(foo)-methods of this class are the types allowed as root-components in the XPECT_SETUP section.</li>
+ * <li>@{@link XpectGuiceModule} The annotated class is a google Guice module. The module will be mixed into the current language’s injector.</li>
+ * </ul>
+ * The @XpectImport annotation is valid on
+ * <ul>
+ * <li>all Xpect Java test classes</li>
+ * <li>on Java classes that are used as parameter types of @Xpect test methods</li>
+ * <li>on Java annotations that are used on parameter types on @Xpect test methods</li>
+ * <li>on Java classes that are contributions</li>
+ * <li>on super classes of any of the classes mentioned above.</li>
+ * </ul>
+ */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })

--- a/org.xpect/src/org/xpect/XpectReplace.java
+++ b/org.xpect/src/org/xpect/XpectReplace.java
@@ -6,6 +6,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * To replace any contribution (even the ones shipped with Xpect), you can annotate your own contribution with @XpectReplace(FooBar). FooBar being the contribution you want to
+ * replace. A contribution that has been replaced is not used any further by Xpect.
+ */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })

--- a/org.xpect/src/org/xpect/XpectRequiredEnvironment.java
+++ b/org.xpect/src/org/xpect/XpectRequiredEnvironment.java
@@ -6,6 +6,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * The annotation @org.xpect.XpectRequiredEnvironment can be used on contributions to activate them only for the specified environments.
+ * Example: @XpectRequiredEnvironment(Environment.STANDALONE_TEST)<br>
+ * This allows to have implementations of contributions that are specific to certain environments.
+ */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/org.xpect/src/org/xpect/setup/XpectSetupComponent.java
+++ b/org.xpect/src/org/xpect/setup/XpectSetupComponent.java
@@ -8,6 +8,10 @@ import java.lang.annotation.Target;
 
 import org.xpect.XpectContributionRole;
 
+/**
+ * Marks a class as a component in the XPECT_SETUP section. For this to work, the test must import a {@link XpectSetupRoot} with an add(Foo) method, where Foo is your
+ * XpectSetupComponent class. The {@link XpectSetupRoot} class should have an @XpectImport for your component class.
+ */
 @Inherited
 @XpectContributionRole
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.xpect/src/org/xpect/setup/XpectSetupFactory.java
+++ b/org.xpect/src/org/xpect/setup/XpectSetupFactory.java
@@ -7,7 +7,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.xpect.XpectContributionRole;
+import org.xpect.XpectImport;
 
+/**
+ * This annotation is used to mark a class as a XpectSetupFactory. The class must be imported in a test via @{@link XpectImport}.<br>
+ * All methods annotated with @Creates contribute objects to the Xpect Setup and can be injected into @Xpect methods and other setup contributions. The class is instantiated and
+ * managed by the StateContainer.
+ */
 @Inherited
 @XpectContributionRole
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.xpect/src/org/xpect/setup/XpectSetupRoot.java
+++ b/org.xpect/src/org/xpect/setup/XpectSetupRoot.java
@@ -8,6 +8,12 @@ import java.lang.annotation.Target;
 
 import org.xpect.XpectContributionRole;
 
+/**
+ * Marks a class to be a XpectSetupRoot contribution to the Xpect Test Setup.<br>
+ * The types of the add(foo)-methods of this class are the types allowed as root-components in the XPECT_SETUP section. They should be @{@link XpectSetupComponent}s. The
+ * initialization will read the components from the XPECT_SETUP section and call the add(...) methods accordingly. Furthermore classes annotated with @XpectSetupRoot can be invoked
+ * with ISetupInitializer.initialize(T).
+ */
 @Inherited
 @XpectContributionRole
 @Retention(RetentionPolicy.RUNTIME)

--- a/org.xpect/src/org/xpect/state/Creates.java
+++ b/org.xpect/src/org/xpect/state/Creates.java
@@ -4,6 +4,12 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import org.xpect.setup.XpectSetupFactory;
+
+/**
+ * Used to mark factory methods in a {@link XpectSetupFactory}. Instances returned from these factory methods can be injected in Xpect test methods and setup contributions. An
+ * Annotation can be given to identify exactly one creation method/instance during injection. Otherwise, the matching is done by type.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Creates {
 	Class<? extends Annotation> value() default Default.class;


### PR DESCRIPTION
Added filter by severity to ValidationTest to address the issue and
report only the issues of the requested severity.

Change-Id: Iff31150199231854e709e03c41e0ab34909427f7
Signed-off-by: Stefan Winkler stefan@winklerweb.net
