### PR TITLE
Allow to format/manipulate the expectation string before assertion

### DIFF
--- a/org.xpect.releng/Xpect - install and test.launch
+++ b/org.xpect.releng/Xpect - install and test.launch
@@ -13,6 +13,6 @@
 <stringAttribute key="M2_USER_SETTINGS" value=""/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/jdk1.7.0_55.jdk"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.xpect.releng}/../"/>
 </launchConfiguration>

--- a/org.xpect.tests/src/org/xpect/tests/expectation/impl/ExpectationTest.java
+++ b/org.xpect.tests/src/org/xpect/tests/expectation/impl/ExpectationTest.java
@@ -1,0 +1,40 @@
+package org.xpect.tests.expectation.impl;
+
+import java.util.Arrays;
+
+import org.junit.runner.RunWith;
+import org.xpect.expectation.ILinesExpectation;
+import org.xpect.expectation.LinesExpectation;
+import org.xpect.lib.XpectTestResultTest;
+import org.xpect.runner.Xpect;
+import org.xpect.runner.XpectRunner;
+import org.xpect.runner.XpectSuiteClasses;
+
+import com.google.common.base.Function;
+
+/**
+ * @author Dennis Huebner - Initial contribution and API
+ *
+ */
+@RunWith(XpectRunner.class)
+@XpectSuiteClasses(XpectTestResultTest.class)
+public class ExpectationTest {
+
+	@Xpect
+	public void expectedExpectation(ILinesExpectation expectation) {
+		expectation.assertEquals(Arrays.asList(new String[] { "Hallo <tester>!" }));
+	}
+
+	@Xpect
+	public void modifiedExpectation(@LinesExpectation(expectationFormatter = TestExpectationFormatter.class) ILinesExpectation expectation) {
+		expectation.assertEquals(Arrays.asList(new String[] { "Hallo Dennis!" }));
+	}
+
+	static public class TestExpectationFormatter implements Function<String, String> {
+
+		@Override
+		public String apply(String input) {
+			return input.replace("<tester>", "Dennis");
+		}
+	}
+}

--- a/org.xpect.tests/src/org/xpect/tests/expectation/impl/expectations.xt
+++ b/org.xpect.tests/src/org/xpect/tests/expectation/impl/expectations.xt
@@ -1,0 +1,8 @@
+   XPECT_SETUP org.xpect.tests.expectation.impl.ExpectationTest END_SETUP  
+
+// not modified
+XPECT expectedExpectation --> Hallo <tester>!
+
+// modified
+XPECT modifiedExpectation --> Hallo <tester>!
+

--- a/org.xpect/src/org/xpect/expectation/ByPassExpectationImpl.java
+++ b/org.xpect/src/org/xpect/expectation/ByPassExpectationImpl.java
@@ -1,0 +1,16 @@
+package org.xpect.expectation;
+
+import com.google.common.base.Function;
+
+/**
+ * @author Dennis Huebner - Initial contribution and API
+ *
+ */
+final public class ByPassExpectationImpl implements Function<String,String> {
+
+	@Override
+	public String apply(String input) {
+		return input;
+	}
+	
+}

--- a/org.xpect/src/org/xpect/expectation/LinesExpectation.java
+++ b/org.xpect/src/org/xpect/expectation/LinesExpectation.java
@@ -26,7 +26,9 @@ public @interface LinesExpectation {
 	boolean caseSensitive() default true;
 
 	Class<? extends Function<Object, String>> itemFormatter() default ToString.class;
-
+	
+	Class<? extends Function<String, String>> expectationFormatter() default ByPassExpectationImpl.class;
+	
 	boolean ordered() default false;
 
 	boolean quoted() default false;

--- a/org.xpect/src/org/xpect/expectation/impl/LinesExpectationImpl.java
+++ b/org.xpect/src/org/xpect/expectation/impl/LinesExpectationImpl.java
@@ -3,11 +3,13 @@ package org.xpect.expectation.impl;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.xtext.util.Exceptions;
 import org.eclipse.xtext.util.Pair;
 import org.junit.Assert;
 import org.junit.ComparisonFailure;
 import org.xpect.XpectArgument;
 import org.xpect.XpectImport;
+import org.xpect.expectation.ByPassExpectationImpl;
 import org.xpect.expectation.ILinesExpectation;
 import org.xpect.expectation.LinesExpectation;
 import org.xpect.expectation.impl.ActualCollection.ActualItem;
@@ -15,9 +17,12 @@ import org.xpect.expectation.impl.ExpectationCollection.ExpectationItem;
 import org.xpect.setup.XpectSetupFactory;
 import org.xpect.state.Creates;
 import org.xpect.text.Text;
+import org.xpect.util.ReflectionUtil;
 
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import com.google.common.io.ByteProcessor;
 
 @XpectSetupFactory
 @XpectImport(ExpectationRegionProvider.class)
@@ -73,7 +78,22 @@ public class LinesExpectationImpl extends AbstractExpectation implements ILinesE
 			throw new ComparisonFailure(message, expDoc, actDoc);
 		}
 	}
-
+	
+	@Override
+	public String getExpectation() {
+		if (annotation.expectationFormatter() != ByPassExpectationImpl.class) {
+			try {
+				Function<String, String> func = annotation.expectationFormatter().newInstance();
+				return func.apply(super.getExpectation());
+			} catch (InstantiationException e) {
+				Exceptions.throwUncheckedException(e);
+			} catch (IllegalAccessException e) {
+				Exceptions.throwUncheckedException(e);
+			}
+		}
+		return super.getExpectation();
+	}
+	
 	@Creates
 	public ILinesExpectation create() {
 		return this;


### PR DESCRIPTION
Usage:

```
public void modifiedExpectation(@LinesExpectation(expectationFormatter = SomeExpectationFormatter.class) ILinesExpectation expectation) {
}
```